### PR TITLE
Hunger and Happiness loss is now based on the streaks of completed qu…

### DIFF
--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -693,7 +693,7 @@
             <!-- Scrollable task list -->
             <div class="scrollable-tasks" id="dailyTasks">
                 {% for quest in user_quests %}
-                {% if quest.status != 'inactive' %}
+                {% if quest.status != 'inactive' and quest.status != 'completed' %}
                 <div class="task-wrapper">
                     <div class="task {% if quest.status == 'completed' %}completed-task{% endif %}" data-task-id="{{ quest.id }}">
                         <input type="checkbox" class="complete-checkbox styled-checkbox" onclick="markTaskComplete('{{ quest.id }}', 'daily')"


### PR DESCRIPTION
Added streaks to each quest that is updated when the quest is refreshed. If the quest is completed before 1 refresh period.
Aka if it is a daily quest with a due date of Tuesday Midnight and was refreshed on Wednesday Noon, it would add 1 to the streak, but if it was refreshed Thursday, it has been too long and the streak is set back to zero.

Hunger and Happiness decay rate is dependent on the weighted value of all active streaks 